### PR TITLE
feat: add sport/region selector for testing with live data

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -10,11 +10,15 @@ import SettingsPanel from '@/components/SettingsPanel';
 
 export default function Dashboard() {
   const { settings, updateSettings, resetSettings } = useSettings();
-  const { data, isLoading, isError, error, isRefetching, refetch } = useOdds(settings);
+  const [sport, setSport] = useState('auto_horse_racing');
+  const [region, setRegion] = useState('uk');
+  const { data, isLoading, isError, error, isRefetching, refetch } = useOdds(settings, sport, region);
   const [showSettings, setShowSettings] = useState(false);
 
   const races = data?.races ?? [];
   const stats = data?.stats ?? null;
+
+  const isHorseRacing = sport === 'auto_horse_racing';
 
   return (
     <div className="min-h-screen bg-gray-50">
@@ -22,6 +26,10 @@ export default function Dashboard() {
         stats={stats}
         isLoading={isLoading}
         isRefetching={isRefetching}
+        sport={sport}
+        region={region}
+        onSportChange={setSport}
+        onRegionChange={setRegion}
         onRefresh={() => refetch()}
         onToggleSettings={() => setShowSettings((s) => !s)}
       />
@@ -74,10 +82,11 @@ export default function Dashboard() {
         {/* Empty state */}
         {!isLoading && !isError && races.length === 0 && (
           <div className="text-center py-20">
-            <p className="text-sm text-gray-500 mb-1">No races available</p>
+            <p className="text-sm text-gray-500 mb-1">No events available</p>
             <p className="text-xs text-gray-400">
-              Horse racing data may not be available outside of race days.
-              Check back during UK racing hours.
+              {isHorseRacing
+                ? 'Horse racing data may not be available outside of race days. Try selecting a different sport (e.g. Soccer — EPL or Basketball — NBA) to verify data is flowing.'
+                : 'No events found for this sport and region. Try a different combination.'}
             </p>
           </div>
         )}

--- a/src/components/DashboardHeader.tsx
+++ b/src/components/DashboardHeader.tsx
@@ -1,11 +1,16 @@
 'use client';
 
 import { DashboardStats } from '@/lib/types';
+import { SPORT_OPTIONS, REGION_OPTIONS } from '@/lib/constants';
 
 interface DashboardHeaderProps {
   stats: DashboardStats | null;
   isLoading: boolean;
   isRefetching: boolean;
+  sport: string;
+  region: string;
+  onSportChange: (sport: string) => void;
+  onRegionChange: (region: string) => void;
   onRefresh: () => void;
   onToggleSettings: () => void;
 }
@@ -14,6 +19,10 @@ export default function DashboardHeader({
   stats,
   isLoading,
   isRefetching,
+  sport,
+  region,
+  onSportChange,
+  onRegionChange,
   onRefresh,
   onToggleSettings,
 }: DashboardHeaderProps) {
@@ -23,24 +32,90 @@ export default function DashboardHeader({
 
   return (
     <header className="bg-white border-b border-gray-200 px-4 py-3">
-      <div className="max-w-7xl mx-auto flex items-center justify-between">
-        {/* Title */}
-        <div>
-          <h1 className="text-lg font-bold text-gray-900">
-            Odds Aggregator — Value Detection
-          </h1>
-          <p className="text-xs text-gray-400">
-            UK Horse Racing &middot; Phase 1 MVP
-          </p>
+      <div className="max-w-7xl mx-auto">
+        {/* Top row: title + controls */}
+        <div className="flex items-center justify-between mb-2">
+          <div>
+            <h1 className="text-lg font-bold text-gray-900">
+              Odds Aggregator — Value Detection
+            </h1>
+            <p className="text-xs text-gray-400">Phase 1 MVP</p>
+          </div>
+
+          <div className="flex items-center gap-3">
+            {/* Refresh indicator */}
+            <div className="flex items-center gap-2">
+              {lastRefreshed && (
+                <span className="text-[10px] text-gray-400">
+                  Updated {lastRefreshed}
+                </span>
+              )}
+              {isRefetching && (
+                <span className="inline-block w-2 h-2 rounded-full bg-blue-400 animate-pulse" />
+              )}
+            </div>
+
+            <button
+              onClick={onRefresh}
+              disabled={isLoading || isRefetching}
+              className="px-3 py-1.5 text-xs font-medium text-gray-600 bg-gray-100 rounded hover:bg-gray-200 disabled:opacity-50 transition-colors"
+            >
+              {isRefetching ? 'Refreshing...' : 'Refresh'}
+            </button>
+            <button
+              onClick={onToggleSettings}
+              className="px-3 py-1.5 text-xs font-medium text-gray-600 bg-gray-100 rounded hover:bg-gray-200 transition-colors"
+            >
+              Settings
+            </button>
+          </div>
         </div>
 
-        {/* Stats + controls */}
-        <div className="flex items-center gap-4">
+        {/* Bottom row: sport/region selectors + quick stats */}
+        <div className="flex items-center justify-between">
+          <div className="flex items-center gap-3">
+            {/* Sport selector */}
+            <div className="flex items-center gap-1.5">
+              <label className="text-[10px] uppercase tracking-wider text-gray-400 font-medium">
+                Sport
+              </label>
+              <select
+                value={sport}
+                onChange={(e) => onSportChange(e.target.value)}
+                className="text-xs border border-gray-200 rounded px-2 py-1 bg-white text-gray-700 focus:ring-2 focus:ring-blue-500 focus:border-transparent outline-none"
+              >
+                {SPORT_OPTIONS.map((opt) => (
+                  <option key={opt.key} value={opt.key}>
+                    {opt.label}
+                  </option>
+                ))}
+              </select>
+            </div>
+
+            {/* Region selector */}
+            <div className="flex items-center gap-1.5">
+              <label className="text-[10px] uppercase tracking-wider text-gray-400 font-medium">
+                Region
+              </label>
+              <select
+                value={region}
+                onChange={(e) => onRegionChange(e.target.value)}
+                className="text-xs border border-gray-200 rounded px-2 py-1 bg-white text-gray-700 focus:ring-2 focus:ring-blue-500 focus:border-transparent outline-none"
+              >
+                {REGION_OPTIONS.map((opt) => (
+                  <option key={opt.key} value={opt.key}>
+                    {opt.label}
+                  </option>
+                ))}
+              </select>
+            </div>
+          </div>
+
           {/* Quick stats */}
           {stats && (
             <div className="hidden sm:flex items-center gap-3 text-xs text-gray-500">
               <span>
-                <strong className="text-gray-700">{stats.racesToday}</strong> races
+                <strong className="text-gray-700">{stats.racesToday}</strong> events
               </span>
               <span className="text-gray-300">|</span>
               <span>
@@ -59,33 +134,6 @@ export default function DashboardHeader({
               )}
             </div>
           )}
-
-          {/* Refresh indicator */}
-          <div className="flex items-center gap-2">
-            {lastRefreshed && (
-              <span className="text-[10px] text-gray-400">
-                Updated {lastRefreshed}
-              </span>
-            )}
-            {isRefetching && (
-              <span className="inline-block w-2 h-2 rounded-full bg-blue-400 animate-pulse" />
-            )}
-          </div>
-
-          {/* Action buttons */}
-          <button
-            onClick={onRefresh}
-            disabled={isLoading || isRefetching}
-            className="px-3 py-1.5 text-xs font-medium text-gray-600 bg-gray-100 rounded hover:bg-gray-200 disabled:opacity-50 transition-colors"
-          >
-            {isRefetching ? 'Refreshing...' : 'Refresh'}
-          </button>
-          <button
-            onClick={onToggleSettings}
-            className="px-3 py-1.5 text-xs font-medium text-gray-600 bg-gray-100 rounded hover:bg-gray-200 transition-colors"
-          >
-            Settings
-          </button>
         </div>
       </div>
     </header>

--- a/src/hooks/useOdds.ts
+++ b/src/hooks/useOdds.ts
@@ -171,12 +171,17 @@ async function fetchOpeningOdds(): Promise<Map<string, number>> {
 /**
  * Main hook: fetches odds from our API, saves snapshots, and transforms data.
  */
-export function useOdds(settings: UserSettings) {
+export function useOdds(
+  settings: UserSettings,
+  sport: string = 'auto_horse_racing',
+  region: string = 'uk'
+) {
   return useQuery({
-    queryKey: ['odds', settings.thresholds, settings.fieldSizeMin, settings.fieldSizeMax],
+    queryKey: ['odds', sport, region, settings.thresholds, settings.fieldSizeMin, settings.fieldSizeMax],
     queryFn: async () => {
-      // Fetch current odds
-      const res = await fetch('/api/odds');
+      // Fetch current odds with sport and region params
+      const params = new URLSearchParams({ sport, region });
+      const res = await fetch(`/api/odds?${params}`);
       if (!res.ok) throw new Error(`Failed to fetch odds: ${res.status}`);
       const json = await res.json();
 

--- a/src/lib/constants.ts
+++ b/src/lib/constants.ts
@@ -13,6 +13,31 @@ export const DEFAULT_ODDS_FORMAT = 'decimal';
 // Refresh interval: 60 seconds
 export const REFRESH_INTERVAL_MS = 60_000;
 
+// Available sport options for the dashboard selector.
+// The Odds API uses these keys. 'auto_horse_racing' is our special key
+// that triggers the horse-racing discovery logic.
+export const SPORT_OPTIONS = [
+  { key: 'auto_horse_racing', label: 'Horse Racing (auto-detect)', group: 'Racing' },
+  { key: 'soccer_epl', label: 'Soccer — EPL', group: 'Soccer' },
+  { key: 'soccer_fa_cup', label: 'Soccer — FA Cup', group: 'Soccer' },
+  { key: 'soccer_uefa_champs_league', label: 'Soccer — Champions League', group: 'Soccer' },
+  { key: 'basketball_nba', label: 'Basketball — NBA', group: 'Basketball' },
+  { key: 'americanfootball_nfl', label: 'American Football — NFL', group: 'American Football' },
+  { key: 'icehockey_nhl', label: 'Ice Hockey — NHL', group: 'Ice Hockey' },
+  { key: 'tennis_atp_french_open', label: 'Tennis — ATP', group: 'Tennis' },
+  { key: 'mma_mixed_martial_arts', label: 'MMA', group: 'Combat' },
+  { key: 'boxing_boxing', label: 'Boxing', group: 'Combat' },
+  { key: 'rugbyleague_nrl', label: 'Rugby League — NRL', group: 'Rugby' },
+] as const;
+
+// Region options
+export const REGION_OPTIONS = [
+  { key: 'uk', label: 'UK' },
+  { key: 'us', label: 'US' },
+  { key: 'eu', label: 'EU' },
+  { key: 'au', label: 'AU' },
+] as const;
+
 // Default user settings
 export const DEFAULT_SETTINGS: UserSettings = {
   bankroll: 1000,

--- a/src/lib/odds-api.ts
+++ b/src/lib/odds-api.ts
@@ -5,7 +5,6 @@ import {
 } from './types';
 import {
   ODDS_API_BASE_URL,
-  DEFAULT_REGION,
   DEFAULT_MARKETS,
   DEFAULT_ODDS_FORMAT,
 } from './constants';
@@ -98,12 +97,13 @@ export async function findHorseRacingSportKey(apiKey: string): Promise<string | 
  */
 export async function fetchOdds(
   apiKey: string,
-  sportKey: string
+  sportKey: string,
+  region: string = 'uk'
 ): Promise<ApiResponse<OddsApiEvent[]>> {
   try {
     const params = new URLSearchParams({
       apiKey,
-      regions: DEFAULT_REGION,
+      regions: region,
       markets: DEFAULT_MARKETS,
       oddsFormat: DEFAULT_ODDS_FORMAT,
     });
@@ -136,7 +136,8 @@ export async function fetchOdds(
  * Some APIs expose multiple horse racing categories (e.g., per country).
  */
 export async function fetchHorseRacingOdds(
-  apiKey: string
+  apiKey: string,
+  region: string = 'uk'
 ): Promise<ApiResponse<OddsApiEvent[]>> {
   const result = await fetchSports(apiKey);
   if (!result.data) {
@@ -165,7 +166,7 @@ export async function fetchHorseRacingOdds(
   // Fetch odds for each horse racing sport key
   const allEvents: OddsApiEvent[] = [];
   for (const key of horseRacingKeys) {
-    const oddsResult = await fetchOdds(apiKey, key);
+    const oddsResult = await fetchOdds(apiKey, key, region);
     if (oddsResult.data) {
       allEvents.push(...oddsResult.data);
     }


### PR DESCRIPTION
- API route now accepts ?sport= and ?region= query params
- Dashboard header has Sport and Region dropdown selectors
- 11 sport options: horse racing, EPL, Champions League, NBA, NFL, NHL, etc.
- 4 region options: UK, US, EU, AU
- Horse racing remains the default, auto-discovering sport keys
- Improved empty state message suggests trying other sports
- useOdds hook passes sport/region through to API

https://claude.ai/code/session_012Fnxipq7Asgag1Q5PQ1u9V