### PR TITLE
fix: horse racing feed silent failure on UK race days

### DIFF
--- a/src/app/api/odds/route.ts
+++ b/src/app/api/odds/route.ts
@@ -39,6 +39,11 @@ export async function GET(request: NextRequest) {
     result = await fetchOdds(apiKey, sport, region);
   }
 
+  // For horse racing, log discovery issues server-side for debugging
+  if (sport === 'auto_horse_racing' && result.error) {
+    console.warn(`[odds] horse racing feed issue: ${result.error}`);
+  }
+
   return NextResponse.json({
     data: result.data,
     error: result.error,

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -85,7 +85,7 @@ export default function Dashboard() {
             <p className="text-sm text-gray-500 mb-1">No events available</p>
             <p className="text-xs text-gray-400">
               {isHorseRacing
-                ? 'Horse racing data may not be available outside of race days. Try selecting a different sport (e.g. Soccer — EPL or Basketball — NBA) to verify data is flowing.'
+                ? 'No horse racing events found. If racing is scheduled today, check the server logs for discovery details. Try selecting a different sport (e.g. Soccer — EPL) to verify data is flowing.'
                 : 'No events found for this sport and region. Try a different combination.'}
             </p>
           </div>

--- a/src/lib/odds-api.ts
+++ b/src/lib/odds-api.ts
@@ -9,6 +9,19 @@ import {
   DEFAULT_ODDS_FORMAT,
 } from './constants';
 
+// Well-known horse racing sport keys on The Odds API.
+// These are tried directly before falling back to dynamic discovery.
+const KNOWN_HORSE_RACING_KEYS = [
+  'horse_racing',
+  'horse_racing_gbr',
+  'horse_racing_uk',
+  'horse_racing_ire',
+  'horse_racing_aus',
+  'horse_racing_usa',
+  'horseracing',
+  'horseracing_uk',
+];
+
 let cachedApiUsage = {
   requestsRemaining: null as number | null,
   requestsUsed: null as number | null,
@@ -32,7 +45,8 @@ function extractApiUsage(headers: Headers) {
 export async function fetchSports(apiKey: string): Promise<ApiResponse<OddsApiSport[]>> {
   try {
     const url = `${ODDS_API_BASE_URL}/sports?apiKey=${apiKey}`;
-    const response = await fetch(url, { next: { revalidate: 3600 } });
+    // Short cache — horse racing keys are dynamic (appear/disappear with race meetings)
+    const response = await fetch(url, { next: { revalidate: 300 } });
 
     extractApiUsage(response.headers);
 
@@ -62,15 +76,8 @@ export async function findHorseRacingSportKey(apiKey: string): Promise<string | 
   const result = await fetchSports(apiKey);
   if (!result.data) return null;
 
-  // Look for horse racing keys — try exact matches first, then partial
-  const horseRacingKeys = [
-    'horse_racing',
-    'horse_racing_uk',
-    'horseracing',
-    'horseracing_uk',
-  ];
-
-  for (const key of horseRacingKeys) {
+  // Try exact matches from the known keys list first
+  for (const key of KNOWN_HORSE_RACING_KEYS) {
     const sport = result.data.find((s) => s.key === key && s.active);
     if (sport) return sport.key;
   }
@@ -80,13 +87,14 @@ export async function findHorseRacingSportKey(apiKey: string): Promise<string | 
     (s) =>
       s.active &&
       (s.title.toLowerCase().includes('horse') ||
-        s.group.toLowerCase().includes('horse'))
+        s.group.toLowerCase().includes('horse') ||
+        s.group.toLowerCase().includes('racing'))
   );
   if (byTitle) return byTitle.key;
 
   console.warn(
     'Could not find horse racing sport key. Available sports:',
-    result.data.map((s) => `${s.key} (${s.title})`).join(', ')
+    result.data.map((s) => `${s.key} (${s.title}) [active=${s.active}]`).join(', ')
   );
   return null;
 }
@@ -133,43 +141,84 @@ export async function fetchOdds(
 
 /**
  * Fetch odds for all discovered horse racing sport keys.
- * Some APIs expose multiple horse racing categories (e.g., per country).
+ *
+ * Strategy:
+ * 1. Discover active horse racing keys via /sports endpoint (1 API call, 5-min cache)
+ * 2. If discovery finds nothing, fall back to trying well-known keys directly
+ * 3. Report an explicit error if no horse racing data is found anywhere
  */
 export async function fetchHorseRacingOdds(
   apiKey: string,
   region: string = 'uk'
 ): Promise<ApiResponse<OddsApiEvent[]>> {
-  const result = await fetchSports(apiKey);
-  if (!result.data) {
-    return { data: null, error: result.error || 'Failed to fetch sports', apiUsage: getApiUsage() };
-  }
-
-  // Find all active horse racing sport keys
-  const horseRacingKeys = result.data
-    .filter(
-      (s) =>
-        s.active &&
-        (s.key.includes('horse') ||
-          s.title.toLowerCase().includes('horse') ||
-          s.group.toLowerCase().includes('horse'))
-    )
-    .map((s) => s.key);
-
-  if (horseRacingKeys.length === 0) {
-    return {
-      data: [],
-      error: null,
-      apiUsage: getApiUsage(),
-    };
-  }
-
-  // Fetch odds for each horse racing sport key
   const allEvents: OddsApiEvent[] = [];
-  for (const key of horseRacingKeys) {
+  const triedKeys = new Set<string>();
+
+  // Step 1: Discover active horse racing keys via /sports endpoint.
+  const sportsResult = await fetchSports(apiKey);
+  let discoveredKeys: string[] = [];
+
+  if (sportsResult.data) {
+    discoveredKeys = sportsResult.data
+      .filter(
+        (s) =>
+          s.active &&
+          (s.key.includes('horse') ||
+            s.key.includes('racing') ||
+            s.title.toLowerCase().includes('horse') ||
+            s.group.toLowerCase().includes('horse') ||
+            s.group.toLowerCase().includes('racing'))
+      )
+      .map((s) => s.key);
+
+    if (discoveredKeys.length > 0) {
+      console.log('Horse racing: discovered active keys:', discoveredKeys);
+    } else {
+      console.warn(
+        'Horse racing: no active keys found via discovery.',
+        'Available sports:',
+        sportsResult.data.map((s) => `${s.key} [active=${s.active}]`).join(', ')
+      );
+    }
+  } else {
+    console.error('Horse racing: /sports endpoint failed:', sportsResult.error);
+  }
+
+  // Fetch odds for all discovered keys
+  for (const key of discoveredKeys) {
+    triedKeys.add(key);
     const oddsResult = await fetchOdds(apiKey, key, region);
-    if (oddsResult.data) {
+    if (oddsResult.data && oddsResult.data.length > 0) {
       allEvents.push(...oddsResult.data);
     }
+  }
+
+  // Step 2: If discovery returned nothing, fall back to well-known keys.
+  // This handles the case where /sports is stale, lists keys as inactive,
+  // or uses a key format we didn't match on.
+  if (allEvents.length === 0) {
+    const fallbackKeys = KNOWN_HORSE_RACING_KEYS.filter((k) => !triedKeys.has(k));
+    if (fallbackKeys.length > 0) {
+      console.log('Horse racing: trying known fallback keys:', fallbackKeys);
+      for (const key of fallbackKeys) {
+        triedKeys.add(key);
+        const oddsResult = await fetchOdds(apiKey, key, region);
+        if (oddsResult.data && oddsResult.data.length > 0) {
+          allEvents.push(...oddsResult.data);
+          // Found data — no need to try remaining fallbacks
+          break;
+        }
+      }
+    }
+  }
+
+  if (allEvents.length === 0) {
+    return {
+      data: [],
+      error: 'No horse racing events found. Tried keys: ' + Array.from(triedKeys).join(', ') +
+        '. Check server logs for discovery details.',
+      apiUsage: getApiUsage(),
+    };
   }
 
   return { data: allEvents, error: null, apiUsage: getApiUsage() };


### PR DESCRIPTION
The horse racing feed had three compounding issues that caused it to silently return empty data while other sports continued working:

1. Stale sports cache (1hr): fetchSports() cached the /sports endpoint for 3600s. Horse racing keys on The Odds API are dynamic — they appear/disappear with race meetings. If the cache was populated when no racing was active, it stayed stale. Reduced to 300s.

2. Silent empty return: when no horse racing keys were discovered, fetchHorseRacingOdds returned {data: [], error: null} — empty data with no error. The dashboard showed "may not be available outside race days" instead of flagging a feed failure.

3. No fallback keys: discovery depended entirely on the /sports endpoint returning active horse racing entries. If the API listed keys as inactive or used an unrecognised format, the feed returned nothing.

Fix: discovery-first with known-key fallback strategy. Try /sports discovery first (1 API call, 5-min cache), then fall back to a list of well-known horse racing keys (horse_racing, horse_racing_gbr, etc). Added structured logging and explicit error reporting when no data is found.

https://claude.ai/code/session_017ZsvswJ6FVRFpyktL9FnUN