### PR TITLE
fix: improve Racing API error handling and Edge runtime compatibility

### DIFF
--- a/src/app/api/racing/route.ts
+++ b/src/app/api/racing/route.ts
@@ -12,38 +12,46 @@ export const dynamic = 'force-dynamic';
  * them into the same OddsApiEvent format used by the rest of the dashboard.
  */
 export async function GET(request: NextRequest) {
-  const username = process.env.RACING_API_USERNAME;
-  const password = process.env.RACING_API_PASSWORD;
+  try {
+    const username = process.env.RACING_API_USERNAME;
+    const password = process.env.RACING_API_PASSWORD;
 
-  if (!username || !password) {
-    return NextResponse.json(
-      {
+    if (!username || !password) {
+      return NextResponse.json(
+        {
+          data: null,
+          error:
+            'Racing API credentials not configured. Add RACING_API_USERNAME and RACING_API_PASSWORD to your Vercel Environment Variables, then redeploy.',
+        },
+        { status: 200 }
+      );
+    }
+
+    const { searchParams } = new URL(request.url);
+    const day = (searchParams.get('day') || 'today') as 'today' | 'tomorrow';
+
+    const result = await fetchRacecards(username, password, day);
+
+    if (!result.data) {
+      return NextResponse.json({
         data: null,
-        error:
-          'Racing API credentials not configured. Add RACING_API_USERNAME and RACING_API_PASSWORD to your environment variables.',
-      },
-      { status: 500 }
-    );
-  }
+        error: result.error,
+      });
+    }
 
-  const { searchParams } = new URL(request.url);
-  const day = (searchParams.get('day') || 'today') as 'today' | 'tomorrow';
+    const events = transformRacecardsToEvents(result.data);
 
-  const result = await fetchRacecards(username, password, day);
-
-  if (!result.data) {
+    return NextResponse.json({
+      data: events,
+      error: null,
+      racecardCount: result.data.length,
+      source: 'the-racing-api',
+    });
+  } catch (err) {
+    console.error('Racing API route error:', err);
     return NextResponse.json({
       data: null,
-      error: result.error,
+      error: `Racing API route error: ${err instanceof Error ? err.message : String(err)}`,
     });
   }
-
-  const events = transformRacecardsToEvents(result.data);
-
-  return NextResponse.json({
-    data: events,
-    error: null,
-    racecardCount: result.data.length,
-    source: 'the-racing-api',
-  });
 }


### PR DESCRIPTION
- Use btoa() instead of Buffer.from() for Basic Auth encoding (Buffer is not available on Vercel Edge runtime)
- Return 200 with error message instead of 500 for missing credentials (so the frontend can display the actual error)
- Add try/catch around entire route handler
- Handle different Racing API response shapes (array vs {racecards:[]})
- Add detailed console logging for debugging the live API response structure (racecard keys, runner keys)

https://claude.ai/code/session_017ZsvswJ6FVRFpyktL9FnUN