### PR TITLE
fix: explicit Racing API odds format + transformed debug mode

### DIFF
--- a/src/app/api/racing/route.ts
+++ b/src/app/api/racing/route.ts
@@ -66,6 +66,27 @@ export async function GET(request: NextRequest) {
 
     const events = transformRacecardsToEvents(result.data);
 
+    // Transformed debug mode: show the first transformed event
+    // to verify bookmakers and outcomes are mapped correctly
+    const transformed = searchParams.get('transformed') === 'true';
+    if (transformed) {
+      const firstEvent = events[0] || null;
+      return NextResponse.json({
+        eventCount: events.length,
+        firstEvent: firstEvent ? {
+          id: firstEvent.id,
+          sport_title: firstEvent.sport_title,
+          home_team: firstEvent.home_team,
+          commence_time: firstEvent.commence_time,
+          bookmakerCount: firstEvent.bookmakers.length,
+          bookmakerNames: firstEvent.bookmakers.map((b) => b.title),
+          firstBookmaker: firstEvent.bookmakers[0] || null,
+          totalOutcomes: firstEvent.bookmakers[0]?.markets[0]?.outcomes?.length || 0,
+        } : null,
+        source: 'the-racing-api',
+      });
+    }
+
     return NextResponse.json({
       data: events,
       error: null,


### PR DESCRIPTION
Rewrote odds extraction to directly use the confirmed format:
  runner.odds = [{ bookmaker, decimal, fractional, ... }]
instead of dynamic field detection which may have missed the data.

Added ?transformed=true debug endpoint to verify the transformer produces correct bookmaker/outcome data.

https://claude.ai/code/session_017ZsvswJ6FVRFpyktL9FnUN