### PR TITLE
fix: filter to UK & Ireland races only, widen field size defaults

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -115,20 +115,6 @@ export default function Dashboard() {
           </div>
         )}
 
-        {/* Client diagnostic — remove once odds are displaying correctly */}
-        {!isLoading && races.length > 0 && (
-          <div className="mb-4 p-3 bg-yellow-50 border border-yellow-200 rounded text-xs font-mono text-gray-700">
-            <div className="font-bold mb-1">Data diagnostic (will remove once working):</div>
-            <div>Races received: {races.length}</div>
-            <div>First race: {races[0]?.eventName}</div>
-            <div>Runners in first race: {races[0]?.runners.length}</div>
-            <div>First runner name: {races[0]?.runners[0]?.runnerName ?? 'NONE'}</div>
-            <div>First runner bestOdds: {String(races[0]?.runners[0]?.bestCurrentOdds ?? 'NULL')}</div>
-            <div>First runner bookmakerCount: {races[0]?.runners[0]?.bookmakerOdds?.length ?? 0}</div>
-            <div>First runner bestBookmaker: {races[0]?.runners[0]?.bestBookmaker ?? 'NONE'}</div>
-          </div>
-        )}
-
         {/* Race cards */}
         {races.map((race) => (
           <RaceCard key={race.eventId} race={race} settings={settings} />

--- a/src/lib/constants.ts
+++ b/src/lib/constants.ts
@@ -49,8 +49,8 @@ export const DEFAULT_SETTINGS: UserSettings = {
   kellyMode: 'half',
   kellyMultiplier: 0.5,
   maxLiabilityPct: 1.5,
-  fieldSizeMin: 8,
-  fieldSizeMax: 14,
+  fieldSizeMin: 2,
+  fieldSizeMax: 30,
 };
 
 // Compression colour thresholds (maps to tailwind classes)

--- a/src/lib/racing-api.ts
+++ b/src/lib/racing-api.ts
@@ -56,8 +56,13 @@ export async function fetchRacecards(
       racecards = [];
     }
 
-    // Filter out abandoned races
-    racecards = racecards.filter((r: any) => !r.is_abandoned);
+    // Filter out abandoned races and non-UK/IRE races (no bookmaker odds for other regions)
+    racecards = racecards.filter((r: any) => {
+      if (r.is_abandoned) return false;
+      // Standard plan only has bookmaker odds for UK (GB) & Ireland (IRE)
+      const region = (r.region || '').toUpperCase();
+      return region === 'GB' || region === 'IRE';
+    });
 
     console.log(`Racing API: got ${racecards.length} racecards from ${url}`);
     if (racecards.length > 0 && racecards[0].runners?.length > 0) {


### PR DESCRIPTION
Root cause: The Racing API Standard plan only has bookmaker odds for UK (GB) & Ireland (IRE) races. Non-UK races (e.g. Sha Tin, Hong Kong) had racecards but no odds, and were appearing first due to the field size filter sorting.

- Filter racecards to region GB/IRE only (where odds are available)
- Widen default field size from 8-14 to 2-30 to include all UK race sizes
- Remove temporary diagnostic panel

https://claude.ai/code/session_017ZsvswJ6FVRFpyktL9FnUN