### PR TITLE
feat: add market average odds and cross-bookmaker compression signals

### DIFF
--- a/src/components/RaceCard.tsx
+++ b/src/components/RaceCard.tsx
@@ -75,11 +75,11 @@ export default function RaceCard({ race, settings }: RaceCardProps) {
           <thead>
             <tr className="text-[10px] uppercase tracking-wider text-gray-400 border-b border-gray-100">
               <th className="px-3 py-2 font-medium">Horse</th>
-              <th className="px-2 py-2 font-medium text-center">Initial</th>
-              <th className="px-2 py-2 font-medium text-center">Current Best</th>
-              <th className="px-2 py-2 font-medium text-center">Compression</th>
+              <th className="px-2 py-2 font-medium text-center">Mkt Avg</th>
+              <th className="px-2 py-2 font-medium text-center">Best Price</th>
+              <th className="px-2 py-2 font-medium text-center">Spread</th>
               <th className="px-2 py-2 font-medium text-center">Signal</th>
-              <th className="px-2 py-2 font-medium">Bookmaker</th>
+              <th className="px-2 py-2 font-medium">Best Bookie</th>
               <th className="px-2 py-2 font-medium text-right">Kelly Stake</th>
             </tr>
           </thead>

--- a/src/components/RunnerRow.tsx
+++ b/src/components/RunnerRow.tsx
@@ -33,6 +33,7 @@ export default function RunnerRow({ runner, settings, muted }: RunnerRowProps) {
   }
 
   const rowBg = muted ? 'opacity-50' : colors.bg;
+  const bookmakerCount = runner.bookmakerOdds.filter((p) => p.price > 0).length;
 
   return (
     <tr className={`border-b border-gray-100 ${rowBg} hover:bg-gray-50 transition-colors`}>
@@ -43,16 +44,19 @@ export default function RunnerRow({ runner, settings, muted }: RunnerRowProps) {
         </span>
       </td>
 
-      {/* Initial odds */}
+      {/* Market average odds (consensus from all bookmakers) */}
       <td className="px-2 py-2">
         <OddsCell
-          odds={runner.initialOdds}
+          odds={runner.averageOdds}
           impliedPct={runner.impliedProbability}
           muted={muted}
         />
+        <div className="text-[9px] text-gray-400 text-center">
+          {bookmakerCount} bookies
+        </div>
       </td>
 
-      {/* Best current odds */}
+      {/* Best current odds (lowest = best for lay) */}
       <td className="px-2 py-2">
         <OddsCell
           odds={runner.bestCurrentOdds}
@@ -61,7 +65,7 @@ export default function RunnerRow({ runner, settings, muted }: RunnerRowProps) {
         />
       </td>
 
-      {/* Compression */}
+      {/* Compression (spread between widest and tightest bookmaker) */}
       <td className="px-2 py-2 text-center">
         <CompressionBadge
           compressionPercent={runner.compressionPercent}

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -48,7 +48,9 @@ export interface RunnerOdds {
   bookmakerOdds: BookmakerPrice[];
   bestCurrentOdds: number | null;
   bestBookmaker: string | null;
+  worstBookmaker: string | null;
   initialOdds: number | null;
+  averageOdds: number | null;
   impliedProbability: number | null;
   currentImpliedProbability: number | null;
   compressionPercent: number | null;


### PR DESCRIPTION
- Calculate average (consensus) odds across all bookmakers per runner
- Use highest bookmaker price as the "opening" benchmark when no historical Supabase data exists — the spread between the widest and tightest bookmaker price IS a meaningful compression signal
- Show "Mkt Avg" column with aggregate odds and bookmaker count
- Rename columns: Initial→Mkt Avg, Current Best→Best Price, Compression→Spread, Bookmaker→Best Bookie
- impliedProbability now based on market average (consensus) rather than just the best price

Example: if Bet365 offers 6.50 and Betfair Exchange has 5.50, compression = (6.50 - 5.50) / 6.50 × 100 = 15.4% → Conservative signal

https://claude.ai/code/session_017ZsvswJ6FVRFpyktL9FnUN