### PR TITLE
feat: upgrade odds pipeline — batch snapshots, tomorrow's races, bett…

### DIFF
--- a/src/components/DashboardHeader.tsx
+++ b/src/components/DashboardHeader.tsx
@@ -40,14 +40,26 @@ export default function DashboardHeader({
             {stats && (
               <div className="hidden sm:flex items-center gap-3 text-xs text-gray-500">
                 <span>
-                  <strong className="text-gray-700">{stats.racesToday}</strong> races
+                  <strong className="text-gray-700">{stats.racesToday}</strong> today
                 </span>
+                {stats.racesTomorrow > 0 && (
+                  <>
+                    <span className="text-gray-300">|</span>
+                    <span>
+                      <strong className="text-purple-600">{stats.racesTomorrow}</strong> tomorrow
+                    </span>
+                  </>
+                )}
                 <span className="text-gray-300">|</span>
                 <span>
                   <strong className={stats.valueAlerts > 0 ? 'text-red-600' : 'text-gray-700'}>
                     {stats.valueAlerts}
                   </strong>{' '}
                   alerts
+                </span>
+                <span className="text-gray-300">|</span>
+                <span className={stats.supabaseConnected ? 'text-green-600' : 'text-amber-500'}>
+                  DB: {stats.supabaseConnected ? 'connected' : 'offline'}
                 </span>
               </div>
             )}

--- a/src/components/DashboardStats.tsx
+++ b/src/components/DashboardStats.tsx
@@ -12,16 +12,34 @@ export default function DashboardStats({ stats }: DashboardStatsProps) {
       label: 'Races Today',
       value: stats.racesToday.toString(),
       color: 'text-blue-600',
+      subtitle: null as string | null,
+    },
+    {
+      label: 'Tomorrow',
+      value: stats.racesTomorrow.toString(),
+      color: stats.racesTomorrow > 0 ? 'text-purple-600' : 'text-gray-600',
+      subtitle: stats.racesTomorrow > 0 ? 'Early odds tracking' : null,
     },
     {
       label: 'Value Alerts',
       value: stats.valueAlerts.toString(),
       color: stats.valueAlerts > 0 ? 'text-red-600' : 'text-gray-600',
+      subtitle: null as string | null,
+    },
+    {
+      label: 'Database',
+      value: stats.supabaseConnected
+        ? `${stats.openingOddsCount} stored`
+        : 'Not connected',
+      color: stats.supabaseConnected ? 'text-green-600' : 'text-amber-600',
+      subtitle: stats.supabaseConnected
+        ? `${stats.snapshotsSaved} saved this cycle`
+        : 'Check Supabase env vars',
     },
   ];
 
   return (
-    <div className="grid grid-cols-2 gap-3 mb-4">
+    <div className="grid grid-cols-2 sm:grid-cols-4 gap-3 mb-4">
       {statItems.map((item) => (
         <div
           key={item.label}
@@ -31,6 +49,9 @@ export default function DashboardStats({ stats }: DashboardStatsProps) {
             {item.label}
           </div>
           <div className={`text-xl font-bold ${item.color}`}>{item.value}</div>
+          {item.subtitle && (
+            <div className="text-[10px] text-gray-400 mt-0.5">{item.subtitle}</div>
+          )}
         </div>
       ))}
     </div>

--- a/src/components/RaceCard.tsx
+++ b/src/components/RaceCard.tsx
@@ -22,6 +22,7 @@ export default function RaceCard({ race, settings }: RaceCardProps) {
     month: 'short',
   });
 
+  const isTomorrow = new Date(race.commenceTime).toDateString() !== new Date().toDateString();
   const isMuted = !race.withinFieldSizeFilter;
   const valueRunners = race.runners.filter((r) => r.valueSignal !== 'none');
 
@@ -35,12 +36,19 @@ export default function RaceCard({ race, settings }: RaceCardProps) {
       <div className="flex items-center justify-between px-4 py-3 bg-gray-50 border-b border-gray-200">
         <div className="flex items-center gap-3">
           <div>
-            <Link
-              href={`/races/${race.eventId}`}
-              className="text-sm font-semibold text-gray-900 hover:text-blue-600 transition-colors"
-            >
-              {race.eventName}
-            </Link>
+            <div className="flex items-center gap-2">
+              <Link
+                href={`/races/${race.eventId}`}
+                className="text-sm font-semibold text-gray-900 hover:text-blue-600 transition-colors"
+              >
+                {race.eventName}
+              </Link>
+              {isTomorrow && (
+                <span className="px-1.5 py-0.5 rounded text-[10px] font-medium bg-purple-50 text-purple-600">
+                  TOMORROW
+                </span>
+              )}
+            </div>
             <div className="text-xs text-gray-500">
               {raceDate} &middot; {raceTime}
             </div>
@@ -75,9 +83,10 @@ export default function RaceCard({ race, settings }: RaceCardProps) {
           <thead>
             <tr className="text-[10px] uppercase tracking-wider text-gray-400 border-b border-gray-100">
               <th className="px-3 py-2 font-medium">Horse</th>
+              <th className="px-2 py-2 font-medium text-center">Opening</th>
+              <th className="px-2 py-2 font-medium text-center">Current</th>
               <th className="px-2 py-2 font-medium text-center">Mkt Avg</th>
-              <th className="px-2 py-2 font-medium text-center">Best Price</th>
-              <th className="px-2 py-2 font-medium text-center">Spread</th>
+              <th className="px-2 py-2 font-medium text-center">Move</th>
               <th className="px-2 py-2 font-medium text-center">Signal</th>
               <th className="px-2 py-2 font-medium">Best Bookie</th>
               <th className="px-2 py-2 font-medium text-right">Kelly Stake</th>

--- a/src/components/RunnerRow.tsx
+++ b/src/components/RunnerRow.tsx
@@ -2,7 +2,7 @@
 
 import { RunnerOdds, UserSettings, KellyResult } from '@/lib/types';
 import { COMPRESSION_COLORS } from '@/lib/constants';
-import { kellyLayStake, impliedProbability } from '@/lib/calculations';
+import { kellyLayStake, impliedProbability, formatOdds } from '@/lib/calculations';
 import OddsCell from './OddsCell';
 import CompressionBadge from './CompressionBadge';
 import ValueAlert from './ValueAlert';
@@ -35,6 +35,16 @@ export default function RunnerRow({ runner, settings, muted }: RunnerRowProps) {
   const rowBg = muted ? 'opacity-50' : colors.bg;
   const bookmakerCount = runner.bookmakerOdds.filter((p) => p.price > 0).length;
 
+  // Calculate direction arrow for price movement
+  const moveDirection =
+    runner.initialOdds !== null && runner.bestCurrentOdds !== null
+      ? runner.bestCurrentOdds < runner.initialOdds
+        ? 'down'
+        : runner.bestCurrentOdds > runner.initialOdds
+          ? 'up'
+          : 'flat'
+      : null;
+
   return (
     <tr className={`border-b border-gray-100 ${rowBg} hover:bg-gray-50 transition-colors`}>
       {/* Horse name */}
@@ -42,6 +52,27 @@ export default function RunnerRow({ runner, settings, muted }: RunnerRowProps) {
         <span className={`text-sm font-medium ${muted ? 'text-gray-400' : 'text-gray-900'}`}>
           {runner.runnerName}
         </span>
+      </td>
+
+      {/* Opening odds (first captured from DB, or worst bookmaker as proxy) */}
+      <td className="px-2 py-2">
+        <div className="text-center">
+          <div className={`text-sm font-mono font-semibold ${muted ? 'text-gray-400' : 'text-gray-900'}`}>
+            {formatOdds(runner.initialOdds)}
+          </div>
+          <div className="text-[9px] text-gray-400">
+            {runner.hasDbOpening ? 'from DB' : 'est.'}
+          </div>
+        </div>
+      </td>
+
+      {/* Current best odds (lowest across all bookmakers) */}
+      <td className="px-2 py-2">
+        <OddsCell
+          odds={runner.bestCurrentOdds}
+          impliedPct={runner.currentImpliedProbability}
+          muted={muted}
+        />
       </td>
 
       {/* Market average odds (consensus from all bookmakers) */}
@@ -56,21 +87,19 @@ export default function RunnerRow({ runner, settings, muted }: RunnerRowProps) {
         </div>
       </td>
 
-      {/* Best current odds (lowest = best for lay) */}
-      <td className="px-2 py-2">
-        <OddsCell
-          odds={runner.bestCurrentOdds}
-          impliedPct={runner.currentImpliedProbability}
-          muted={muted}
-        />
-      </td>
-
-      {/* Compression (spread between widest and tightest bookmaker) */}
+      {/* Price movement (compression from opening to current) */}
       <td className="px-2 py-2 text-center">
         <CompressionBadge
           compressionPercent={runner.compressionPercent}
           signal={runner.valueSignal}
         />
+        {moveDirection && (
+          <div className="text-[10px] mt-0.5">
+            {moveDirection === 'down' && <span className="text-green-600" title="Price shortened (drifted in)">&#9660;</span>}
+            {moveDirection === 'up' && <span className="text-red-500" title="Price drifted out">&#9650;</span>}
+            {moveDirection === 'flat' && <span className="text-gray-400">&#8212;</span>}
+          </div>
+        )}
       </td>
 
       {/* Value signal */}

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -41,6 +41,7 @@ export interface RunnerOdds {
   bestBookmaker: string | null;
   worstBookmaker: string | null;
   initialOdds: number | null;
+  hasDbOpening: boolean;
   averageOdds: number | null;
   impliedProbability: number | null;
   currentImpliedProbability: number | null;
@@ -210,6 +211,10 @@ export interface ApiResponse<T> {
 
 export interface DashboardStats {
   racesToday: number;
+  racesTomorrow: number;
   valueAlerts: number;
+  snapshotsSaved: number;
+  supabaseConnected: boolean;
+  openingOddsCount: number;
   lastRefreshed: string | null;
 }


### PR DESCRIPTION
…er columns

- Fix snapshot saving: batch opening check with single query instead of N individual SELECTs (was ~2800 queries per cycle, now 1)
- Fetch tomorrow's races alongside today's for early opening odds capture (Racing API updates tomorrow every 15 mins)
- New table columns: Opening | Current | Mkt Avg | Move | Signal
- Opening column shows DB-stored first odds or estimated from worst bookie
- Move column shows price direction arrows (down=shortened, up=drifted)
- Dashboard stats: Races Today, Tomorrow, Value Alerts, Database status
- Header shows DB connection status and tomorrow race count
- RunnerOdds now tracks hasDbOpening flag
- DashboardStats now tracks supabaseConnected, openingOddsCount, snapshotsSaved

https://claude.ai/code/session_017ZsvswJ6FVRFpyktL9FnUN