### PR TITLE
feat: restructure odds pipeline — Betfair Exchange as current, openin…

### DIFF
--- a/src/app/races/[raceId]/page.tsx
+++ b/src/app/races/[raceId]/page.tsx
@@ -138,8 +138,8 @@ export default function RaceDetailPage({
               <thead>
                 <tr className="text-[10px] uppercase tracking-wider text-gray-400 border-b border-gray-100">
                   <th className="px-3 py-2 font-medium sticky left-0 bg-white">Horse</th>
-                  <th className="px-2 py-2 font-medium text-center">Initial</th>
-                  <th className="px-2 py-2 font-medium text-center">Best</th>
+                  <th className="px-2 py-2 font-medium text-center">Opening Avg</th>
+                  <th className="px-2 py-2 font-medium text-center">Betfair</th>
                   <th className="px-2 py-2 font-medium text-center">Compression</th>
                   <th className="px-2 py-2 font-medium text-center">Signal</th>
                   {/* Get all unique bookmakers */}
@@ -174,15 +174,18 @@ export default function RaceDetailPage({
                         {runner.runnerName}
                       </td>
                       <td className="px-2 py-2 text-center font-mono">
-                        {formatOdds(runner.initialOdds)}
+                        {formatOdds(runner.openingAverageOdds)}
                         {runner.impliedProbability !== null && (
                           <div className="text-[10px] text-gray-400">
                             {formatPercent(runner.impliedProbability)}
                           </div>
                         )}
+                        <div className="text-[9px] text-gray-400">
+                          {runner.hasDbOpening ? 'DB' : 'est.'}
+                        </div>
                       </td>
-                      <td className="px-2 py-2 text-center font-mono font-semibold">
-                        {formatOdds(runner.bestCurrentOdds)}
+                      <td className={`px-2 py-2 text-center font-mono font-semibold ${runner.betfairOdds === null ? 'text-gray-300' : ''}`}>
+                        {runner.betfairOdds !== null ? formatOdds(runner.betfairOdds) : 'N/A'}
                       </td>
                       <td className="px-2 py-2 text-center">
                         <CompressionBadge
@@ -197,13 +200,14 @@ export default function RaceDetailPage({
                         const price = runner.bookmakerOdds.find(
                           (b) => b.bookmakerTitle === bm
                         );
+                        const isBetfair = price?.bookmaker === 'betfair_exchange' || price?.bookmaker === 'betfair_ex';
                         const isBest =
                           price && runner.bestCurrentOdds === price.price;
                         return (
                           <td
                             key={bm}
                             className={`px-2 py-2 text-center font-mono text-xs ${
-                              isBest ? 'font-bold text-blue-600' : 'text-gray-500'
+                              isBetfair ? 'font-bold text-green-700 bg-green-50' : isBest ? 'font-bold text-blue-600' : 'text-gray-500'
                             }`}
                           >
                             {price ? formatOdds(price.price) : '-'}
@@ -253,8 +257,8 @@ export default function RaceDetailPage({
           {/* Kelly calculator */}
           <KellyCalculator
             settings={settings}
-            initialOdds={valueRunner?.initialOdds ?? undefined}
-            currentLayOdds={valueRunner?.bestCurrentOdds ?? undefined}
+            initialOdds={valueRunner?.openingAverageOdds ?? undefined}
+            currentLayOdds={valueRunner?.betfairOdds ?? undefined}
           />
 
           {/* Notes */}

--- a/src/components/DashboardHeader.tsx
+++ b/src/components/DashboardHeader.tsx
@@ -31,7 +31,7 @@ export default function DashboardHeader({
               UK &amp; Ireland Horse Racing — Value Detection
             </h1>
             <p className="text-xs text-gray-400">
-              Live odds from 30+ bookmakers via The Racing API
+              Betfair Exchange lay odds vs 30+ bookmaker opening average
             </p>
           </div>
 

--- a/src/components/RaceCard.tsx
+++ b/src/components/RaceCard.tsx
@@ -86,12 +86,10 @@ export default function RaceCard({ race, settings }: RaceCardProps) {
           <thead>
             <tr className="text-[10px] uppercase tracking-wider text-gray-400 border-b border-gray-100">
               <th className="px-3 py-2 font-medium">Horse</th>
-              <th className="px-2 py-2 font-medium text-center">Opening</th>
-              <th className="px-2 py-2 font-medium text-center">Current</th>
-              <th className="px-2 py-2 font-medium text-center">Mkt Avg</th>
-              <th className="px-2 py-2 font-medium text-center">Move</th>
+              <th className="px-2 py-2 font-medium text-center" title="Average across all 30+ bookmakers at first snapshot">Opening Avg</th>
+              <th className="px-2 py-2 font-medium text-center" title="Betfair Exchange lay price">Betfair</th>
+              <th className="px-2 py-2 font-medium text-center" title="Price movement: Betfair vs Opening Average">Move</th>
               <th className="px-2 py-2 font-medium text-center">Lay / EV</th>
-              <th className="px-2 py-2 font-medium">Best Bookie</th>
               <th className="px-2 py-2 font-medium text-right">Kelly Stake</th>
             </tr>
           </thead>

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -37,14 +37,22 @@ export interface OddsApiEvent {
 export interface RunnerOdds {
   runnerName: string;
   bookmakerOdds: BookmakerPrice[];
+  /** Betfair Exchange price — the price we actually lay at */
+  betfairOdds: number | null;
+  /** Best (lowest) current odds across ALL bookmakers */
   bestCurrentOdds: number | null;
   bestBookmaker: string | null;
   worstBookmaker: string | null;
+  /** Opening average across all bookmakers (from DB first snapshot, or current avg as proxy) */
+  openingAverageOdds: number | null;
+  /** Legacy field — same as openingAverageOdds for backward compat */
   initialOdds: number | null;
   hasDbOpening: boolean;
+  /** Current average across all bookmakers (live market consensus) */
   averageOdds: number | null;
   impliedProbability: number | null;
   currentImpliedProbability: number | null;
+  /** Compression: betfairOdds vs openingAverageOdds */
   compressionPercent: number | null;
   valueSignal: ValueSignalLevel;
   /** Full lay decision from the lay engine */


### PR DESCRIPTION
…g average as model

- Current odds now extracted from Betfair Exchange specifically (key: betfair_exchange)
- Opening/model odds = average across ALL 30+ bookmakers at first DB snapshot
- fetchOpeningOdds() computes average (not minimum) from Supabase opening snapshots
- All math (Kelly, EV, compression) uses Betfair Exchange vs opening average
- Dashboard columns: Horse | Opening Avg | Betfair | Move | Lay/EV | Kelly Stake
- Removed redundant Mkt Avg and Best Bookie columns
- Race detail page updated: highlights Betfair Exchange in green
- DashboardHeader subtitle reflects new data model

https://claude.ai/code/session_017ZsvswJ6FVRFpyktL9FnUN